### PR TITLE
Add diff for many associations without primary keys

### DIFF
--- a/lib/ecto_diff.ex
+++ b/lib/ecto_diff.ex
@@ -305,10 +305,11 @@ defmodule EctoDiff do
 
     diffs =
       if primary_key_fields == [] do
-        max_lenght = max(length(previous), length(current))
+        from = max(length(previous), length(current)) - 1
 
-        Range.new(max_lenght - 1, 0)
-        |> Enum.map([], fn i ->
+        from
+        |> Range.new(0)
+        |> Enum.map(fn i ->
           prev_child = Enum.at(previous, i)
           current_child = Enum.at(current, i)
 
@@ -337,12 +338,12 @@ defmodule EctoDiff do
           do_diff(prev_child, current_child)
         end)
       end
-      |> Enum.reject(&no_changes?/1)
 
-    if diffs == [] do
-      acc
-    else
-      [{field, diffs} | acc]
+    diffs
+    |> Enum.reject(&no_changes?/1)
+    |> case do
+      [] -> acc
+      changed -> [{field, changed} | acc]
     end
   end
 

--- a/priv/repo/migrations/20220113193719_create_boxes.exs
+++ b/priv/repo/migrations/20220113193719_create_boxes.exs
@@ -1,0 +1,9 @@
+defmodule InventoryCore.Repo.Migrations.CreateBoxes do
+  use Ecto.Migration
+
+  def change do
+    create table(:boxes) do
+      add :shapes, {:array, :map}, default: []
+    end
+  end
+end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -7,7 +7,7 @@ defmodule EctoDiff.DataCase do
 
   using do
     quote do
-      alias EctoDiff.{Owner, Pet, Repo}
+      alias EctoDiff.{Owner, Pet, Box, Shape, Repo}
 
       import EctoDiff.DataCase
     end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -7,7 +7,7 @@ defmodule EctoDiff.DataCase do
 
   using do
     quote do
-      alias EctoDiff.{Owner, Pet, Box, Shape, Repo}
+      alias EctoDiff.{Box, Owner, Pet, Repo, Shape}
 
       import EctoDiff.DataCase
     end

--- a/test/support/test_schemas/box.ex
+++ b/test/support/test_schemas/box.ex
@@ -1,0 +1,19 @@
+defmodule EctoDiff.Box do
+  @moduledoc false
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema("boxes") do
+    embeds_many :shapes, EctoDiff.Shape, on_replace: :delete
+  end
+
+  def new(params), do: changeset(%__MODULE__{}, params)
+  def update(struct, params), do: changeset(struct, params)
+
+  defp changeset(struct, params) do
+    struct
+    |> cast(params, [])
+    |> cast_embed(:shapes)
+  end
+end

--- a/test/support/test_schemas/shape.ex
+++ b/test/support/test_schemas/shape.ex
@@ -1,0 +1,13 @@
+defmodule EctoDiff.Shape do
+  @moduledoc false
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  embedded_schema do
+    field :angles, :integer
+  end
+
+  def changeset(struct, params), do: cast(struct, params, [:angles])
+end


### PR DESCRIPTION
Hi, I actively use ecto_diff in my projects, and sometimes I miss the ability to diff on embeds_many associations without a primary key. 
I propose a patch to add this feature.