### PR TITLE
chore: bump version 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Initial release
 
-[Unreleased]: https://github.com/peek-travel/ecto_diff/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/peek-travel/ecto_diff/compare/0.5.1...HEAD
 [0.5.1]: https://github.com/peek-travel/ecto_diff/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/peek-travel/ecto_diff/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/peek-travel/ecto_diff/compare/0.3.0...0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased][]
 
+- Nothing yet
+
+## [0.5.1][]
+
 - Implement diffing for has_many through associations, resolves associated error.
 
 ## [0.5.0][]
@@ -79,6 +83,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Initial release
 
 [Unreleased]: https://github.com/peek-travel/ecto_diff/compare/0.5.0...HEAD
+[0.5.1]: https://github.com/peek-travel/ecto_diff/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/peek-travel/ecto_diff/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/peek-travel/ecto_diff/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/peek-travel/ecto_diff/compare/0.2.2...0.3.0

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule EctoDiff.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.5.1"
   @source_url "https://github.com/peek-travel/ecto_diff"
 
   def project do


### PR DESCRIPTION
Added: Diffing for has_many through associations (previously raises error).